### PR TITLE
attempting to add support for uint32 data

### DIFF
--- a/src/projected_sonar_image_curtain.cpp
+++ b/src/projected_sonar_image_curtain.cpp
@@ -116,6 +116,23 @@ void ProjectedSonarImageCurtain::addMessage(const acoustic_msgs::ProjectedSonarI
       }
       break;
     }
+    case acoustic_msgs::SonarImageData::DTYPE_UINT32:
+    {
+      const uint32_t* sonar_data = reinterpret_cast<const uint32_t*>(msg->image.data.data());
+      auto image_col = vertices_.size();
+
+      for (uint32_t i = start_row; i < end_row; i++)
+      {
+        auto c = color_map_->lookup(sonar_data[i*msg->image.beam_count+beam_number]);
+        auto image_row = i-start_row;
+        auto image_cell = &image_->data.at((image_col+max_ping_count_*image_row)*4);
+        image_cell[0] = c.r*255;
+        image_cell[1] = c.g*255;
+        image_cell[2] = c.b*255;
+        image_cell[3] = c.a*255;
+      }
+      break;
+    }
     case acoustic_msgs::SonarImageData::DTYPE_FLOAT32:
     {
 

--- a/src/projected_sonar_image_display.cpp
+++ b/src/projected_sonar_image_display.cpp
@@ -50,6 +50,11 @@ void ProjectedSonarImageDisplay::processMessage(const acoustic_msgs::ProjectedSo
   case acoustic_msgs::SonarImageData::DTYPE_UINT16:
     color_map_->setRange(0, 1000);
     break;
+  case acoustic_msgs::SonarImageData::DTYPE_UINT32:
+    color_map_->setRange(0, 4000000000);
+    break;
+  // QUESTION(lindzey): Should this at least generate a warning? In other parts
+  //    of the code, using an unsupported DTYPE is an error.
   default:
     color_map_->setRange(-80, -20);
   }

--- a/src/projected_sonar_image_fan.cpp
+++ b/src/projected_sonar_image_fan.cpp
@@ -24,7 +24,7 @@ ProjectedSonarImageFan::ProjectedSonarImageFan( Ogre::SceneManager* scene_manage
   tu->setTextureFiltering(Ogre::FT_MIN, Ogre::FO_ANISOTROPIC);
   tu->setTextureFiltering(Ogre::FT_MAG, Ogre::FO_POINT);
   tu->setTextureFiltering(Ogre::FT_MIP, Ogre::FO_POINT);
-  
+
   texture_ = new rviz::ROSImageTexture();
   if (!texture_)
   {

--- a/src/projected_sonar_image_fan.cpp
+++ b/src/projected_sonar_image_fan.cpp
@@ -150,6 +150,19 @@ void ProjectedSonarImageFan::setMessage(const acoustic_msgs::ProjectedSonarImage
       }
       break;
     }
+    case acoustic_msgs::SonarImageData::DTYPE_UINT32:
+    {
+      const uint32_t* sonar_data = reinterpret_cast<const uint32_t*>(msg->image.data.data());
+      for (uint32_t i = start_row*image->width; i < end_row*image->width; i++)
+      {
+        auto c = color_map_->lookup(sonar_data[i]);
+        image->data.push_back(c.r*255);
+        image->data.push_back(c.g*255);
+        image->data.push_back(c.b*255);
+        image->data.push_back(c.a*255);
+      }
+      break;
+    }
     case acoustic_msgs::SonarImageData::DTYPE_FLOAT32:
     {
       const float* sonar_data = reinterpret_cast<const float*>(msg->image.data.data());


### PR DESCRIPTION
Hi @rolker! We're (finally) converting all our code to use the new acoustic_msgs definitions.

We primarily use the Oculus in a 32 bit mode, so I've tried to add support for that in your plugin.

The resulting image looks mostly right, though there is an odd scattering of white pixels:
![Screenshot from 2022-10-01 22-46-22](https://user-images.githubusercontent.com/65185744/193440127-5e6e765e-c22e-401c-b7b9-7302343a1863.png)

For comparison, here's a screenshot of a PointCloud2 that we generated using a python script (not perfectly synced with above image, and sonar was nodding):
![hacky_pointcloud](https://user-images.githubusercontent.com/65185744/193440142-39e52ef9-7713-45e6-adb4-e6283376079c.png)
