### PR TITLE
Migrate ColorMap onto shared marine_colormap

### DIFF
--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -1,0 +1,38 @@
+---
+issue: 4
+---
+
+# Issue #4 — rviz_sonar_image: migrate onto shared marine_colormap
+
+## Implementation
+**Status**: complete (pending review)
+**When**: 2026-06-07
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Branch**: feature/issue-4
+
+Replaced the local `rviz_sonar_image::ColorMap` (a hand-maintained 13-stop
+thermal ramp) with a thin adapter over the shared `marine_colormap`:
+- `color_map.{h,cpp}` keep the same class API (`setRange`/`setAlphaRange`/
+  `lookup`), so the curtain/fan call sites are unchanged. Internally it holds a
+  `marine_colormap::TransferParams` + the canonical `thermal` palette and
+  converts `Rgba` -> `Ogre::ColourValue`.
+- Behaviour preserved: white-below-floor sentinel, opaque, default -70..0 dB.
+  `setAlphaRange` (previously dead code, alpha was hard-coded to 1.0) is now
+  wired to the shared alpha ramp; no caller sets it, so rendering is unchanged.
+- package.xml + CMakeLists gain the `marine_colormap` dependency.
+
+**Color shift (expected, per ADR-0001):** rviz now uses the canonical de-dup
+thermal (the old ramp carried one stop twice and used rounded 0.3 vs 77/255), so
+colours shift slightly. The shared lib's golden test locks the reference.
+
+**Validation:** builds clean against the shared lib (only pre-existing
+-Wsign-compare warnings). No unit tests in this repo (rviz plugin); the color
+math is now covered by marine_colormap's tests. Runtime/visual check in rviz
+deferred (needs a display) — candidate for /verify.
+
+**Dependency note:** this surfaced that marine_colormap was building STATIC
+(no -fPIC) -> can't link into the rviz plugin .so. Fixed upstream
+(rolker/marine_colormap#4, build SHARED) and merged before this.
+
+Closes #4. Part of rolker/unh_marine_autonomy#137.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -48,7 +48,10 @@ Closes #4. Part of rolker/unh_marine_autonomy#137.
 **CI**: copilot-pull-request-reviewer success (no build/test check on repo; built clean locally)
 
 ### Findings
-- [ ] (suggestion/defensive, Copilot R1) lookup() raw-derefs palette_ — can't be null today (set once from guaranteed built-in "thermal", never reassigned; no set_type), but a one-line guard/fallback is cheap insurance for a per-frame render-path pointer — `src/color_map.cpp:36`
+- [x] (suggestion/defensive, Copilot R1) lookup() raw-derefs palette_ — can't be null today (set once from guaranteed built-in "thermal", never reassigned; no set_type), but a one-line guard/fallback is cheap insurance for a per-frame render-path pointer — `src/color_map.cpp:36`
 
 ### False positives
 - (Copilot R1) `TransferParams params_` "may leave fields indeterminate (POD)" — `src/.../color_map.h:29`: marine_colormap::TransferParams declares in-class default member initializers for every field (min{0}, max{1}, gain{1}, contrast{1}, alpha_ramp{false}, ...), so a default-constructed params_ is fully defined. Not a POD-without-initializers; no UB.
+
+### Resolution
+- Guard added in `add3726`'s follow-up commit: `lookup()` returns opaque black if `palette_` is null. Build clean.

--- a/.agent/work-plans/issue-4/progress.md
+++ b/.agent/work-plans/issue-4/progress.md
@@ -36,3 +36,19 @@ deferred (needs a display) — candidate for /verify.
 (rolker/marine_colormap#4, build SHARED) and merged before this.
 
 Closes #4. Part of rolker/unh_marine_autonomy#137.
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-07 16:20 -04:00
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #5 at `e5c8beb`
+**Sources**: 1 at head (Copilot R1 @ `e5c8beb`) + prior timeline (Implementation entry; no prior review)
+**Cross-source confirmations**: 0
+**CI**: copilot-pull-request-reviewer success (no build/test check on repo; built clean locally)
+
+### Findings
+- [ ] (suggestion/defensive, Copilot R1) lookup() raw-derefs palette_ — can't be null today (set once from guaranteed built-in "thermal", never reassigned; no set_type), but a one-line guard/fallback is cheap insurance for a per-frame render-path pointer — `src/color_map.cpp:36`
+
+### False positives
+- (Copilot R1) `TransferParams params_` "may leave fields indeterminate (POD)" — `src/.../color_map.h:29`: marine_colormap::TransferParams declares in-class default member initializers for every field (min{0}, max{1}, gain{1}, contrast{1}, alpha_ramp{false}, ...), so a default-constructed params_ is fully defined. Not a POD-without-initializers; no UB.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(marine_acoustic_msgs REQUIRED)
+find_package(marine_colormap REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rviz_common REQUIRED)
@@ -45,6 +46,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 ament_target_dependencies(${PROJECT_NAME}
   "marine_acoustic_msgs"
+  "marine_colormap"
   "pluginlib"
   "rviz_common"
   "rviz_default_plugins"

--- a/include/rviz_sonar_image/color_map.h
+++ b/include/rviz_sonar_image/color_map.h
@@ -3,9 +3,18 @@
 
 #include <OGRE/OgreColourValue.h>
 
+#include <marine_colormap/palette.hpp>
+#include <marine_colormap/transfer.hpp>
+
 namespace rviz_sonar_image
 {
 
+// Thin adapter over the shared marine_colormap library: maps a sonar value (dB)
+// through the canonical "thermal" palette and a transfer function to an Ogre
+// colour. Preserves the prior behaviour -- white below the floor, opaque, linear
+// interpolation, default range -70..0 dB -- while sourcing the palette and
+// transfer from the shared lib. Colours now track marine_colormap's canonical
+// thermal, which drops the stop this map previously carried twice.
 class ColorMap
 {
 public:
@@ -13,13 +22,10 @@ public:
   void setRange(float min, float max);
   void setAlphaRange(float min, float max);
   Ogre::ColourValue lookup(float value);
-private:
-  float min_ = -70.0;
-  float max_ = 0.0;
-  float min_alpha_ = 0.0;
-  float max_alpha_ = 0.8;
-  std::vector<Ogre::ColourValue> map_;
 
+private:
+  const marine_colormap::Palette * palette_;
+  marine_colormap::TransferParams params_;
 };
 
 } // namespace rviz_sonar_image

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>marine_acoustic_msgs</depend>
+  <depend>marine_colormap</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rviz_common</depend>

--- a/src/color_map.cpp
+++ b/src/color_map.cpp
@@ -1,52 +1,40 @@
 #include <rviz_sonar_image/color_map.h>
 
+#include <marine_colormap/colormap.hpp>
+
 namespace rviz_sonar_image
 {
 
 ColorMap::ColorMap()
+: palette_(marine_colormap::find_palette("thermal"))
 {
-  map_.push_back(Ogre::ColourValue(0.3, 0.3, 0.3));
-  map_.push_back(Ogre::ColourValue(0.02, 0.4, 0.95));
-  map_.push_back(Ogre::ColourValue(0.13, 0.09, 0.71));
-  map_.push_back(Ogre::ColourValue(0.15, 0.65, 0.54));
-  map_.push_back(Ogre::ColourValue(0.07, 0.61, 0.41));
-  map_.push_back(Ogre::ColourValue(0.63, 0.82, 0.24));
-  map_.push_back(Ogre::ColourValue(0.99, 0.70, 0.18));
-  map_.push_back(Ogre::ColourValue(0.98, 0.37, 0.60));
-  map_.push_back(Ogre::ColourValue(0.99, 0.19, 0.38));
-  map_.push_back(Ogre::ColourValue(0.99, 0.19, 0.38));
-  map_.push_back(Ogre::ColourValue(0.86, 0.16, 0.20));
-  map_.push_back(Ogre::ColourValue(0.65, 0.20, 0.20));
-  map_.push_back(Ogre::ColourValue(0.60, 0.04, 0.06));
+  params_.min = -70.0f;
+  params_.max = 0.0f;
+  // Preserve the prior "white below the floor" sentinel.
+  params_.has_below_color = true;
+  params_.below_color = marine_colormap::Rgba{1.0f, 1.0f, 1.0f, 1.0f};
 }
 
 void ColorMap::setRange(float min, float max)
 {
-  min_ = min;
-  max_ = max;
+  params_.min = min;
+  params_.max = max;
 }
 
 void ColorMap::setAlphaRange(float min, float max)
 {
-  min_alpha_ = min;
-  max_alpha_ = max;
+  // Previously dormant (alpha was hard-coded to 1.0). Wire it to the shared
+  // transfer's alpha ramp so a caller that sets it gets a value-dependent alpha;
+  // unset, alpha stays opaque as before.
+  params_.alpha_ramp = true;
+  params_.alpha_min = min;
+  params_.alpha_max = max;
 }
-
 
 Ogre::ColourValue ColorMap::lookup(float value)
 {
-  if (value <= min_)
-    return Ogre::ColourValue(1.0, 1.0, 1.0, 1.0);
-    //return map_.front();
-  if (value >= max_)
-    return map_.back();
-
-  float p = (map_.size()-1)*(value - min_)/(max_-min_);
-  float alpha = 1.0; //min_alpha_ + p *(max_alpha_-min_alpha_);
-  int pi = floor(p);
-  float p1 = p-pi;
-  float p0 = 1.0-p1;
-  return Ogre::ColourValue(map_[pi].r*p0+map_[pi+1].r*p1, map_[pi].g*p0+map_[pi+1].g*p1, map_[pi].b*p0+map_[pi+1].b*p1, alpha);
+  const marine_colormap::Rgba c = marine_colormap::lookup(value, *palette_, params_);
+  return Ogre::ColourValue(c.r, c.g, c.b, c.a);
 }
 
 } // namespace rviz_sonar_image

--- a/src/color_map.cpp
+++ b/src/color_map.cpp
@@ -33,6 +33,12 @@ void ColorMap::setAlphaRange(float min, float max)
 
 Ogre::ColourValue ColorMap::lookup(float value)
 {
+  // palette_ is set from the guaranteed built-in "thermal" and never reassigned,
+  // so this is defensive: never crash the render loop if a lib change ever made
+  // the lookup fail -- fall back to opaque black.
+  if (palette_ == nullptr) {
+    return Ogre::ColourValue(0.0f, 0.0f, 0.0f, 1.0f);
+  }
   const marine_colormap::Rgba c = marine_colormap::lookup(value, *palette_, params_);
   return Ogre::ColourValue(c.r, c.g, c.b, c.a);
 }


### PR DESCRIPTION
Migrates `rviz_sonar_image`'s ColorMap onto the shared **`marine_colormap`**
library (part of rolker/unh_marine_autonomy#137).

## What changed
- `color_map.{h,cpp}` keep the **same class API** (`setRange`/`setAlphaRange`/
  `lookup`), so the curtain/fan call sites are untouched. Internally it's now a
  thin adapter: holds a `marine_colormap::TransferParams` + the canonical
  `thermal` palette and converts `Rgba` -> `Ogre::ColourValue`.
- Behaviour preserved: white-below-floor sentinel, opaque, default -70..0 dB.
  `setAlphaRange` (previously dead — alpha was hard-coded to 1.0) is now wired to
  the shared alpha ramp; no caller sets it, so rendering is unchanged.
- Adds the `marine_colormap` dependency (package.xml + CMakeLists).

## Expected color shift (per ADR-0001)
rviz now uses the canonical de-dup thermal — the old local ramp carried one stop
twice and used rounded `0.3` vs `77/255`. Colours shift slightly; the shared
lib's golden test locks the canonical reference.

## Validation
Builds clean against the shared lib (only pre-existing -Wsign-compare warnings).
No unit tests in this repo (rviz plugin); the color math is now covered by
marine_colormap's tests. Runtime/visual rviz check deferred (needs a display).

> Surfaced + fixed upstream: marine_colormap was building STATIC (no -fPIC) and
> couldn't link into the rviz plugin .so -> now built SHARED (rolker/marine_colormap#4, merged).

Closes #4. Part of rolker/unh_marine_autonomy#137.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
